### PR TITLE
Always set expiration for party A pre initiate

### DIFF
--- a/src/actions/swap.js
+++ b/src/actions/swap.js
@@ -51,7 +51,8 @@ async function lockFunds (dispatch, getState) {
     counterParty,
     secretParams,
     expiration,
-    link
+    link,
+    isPartyB
   } = getState().swap
   const client = getClient(assets.a.currency)
   let secretHash = secretParams.secretHash
@@ -63,7 +64,7 @@ async function lockFunds (dispatch, getState) {
   }
 
   let swapExpiration
-  if (expiration) {
+  if (isPartyB) {
     swapExpiration = getFundExpiration(expiration, 'b').time
   } else {
     swapExpiration = generateExpiration()


### PR DESCRIPTION
### Description

The initiate swap action would only generate the expiration time if it did not exist in the state. When an initiate call to CAL fails, the expiration is set but needs to be reset on the next run. This PR ensures expiration is always regenerated for Party A before the initiate call. 