### PR TITLE
Fix getting unusedAddress balance with change addresses

### DIFF
--- a/src/actions/wallets.js
+++ b/src/actions/wallets.js
@@ -26,9 +26,12 @@ function waitForWallet (party, currency, wallet) {
     dispatch(chooseWallet(party, wallet))
     const addressesPerCall = 20
     const unusedAddress = (await client.getUnusedAddress()).address
+    const unusedChangeAddress = (await client.getUnusedAddress(true)).address
     let unusedAddressReached = false
+    let unusedChangeAddressReached = false
     let usedAddresses = []
     let addressesIndex = 0
+    let changeAddressesIndex = 0
     while (!unusedAddressReached) {
       let addresses = await client.getAddresses(addressesIndex, addressesPerCall)
       addresses = addresses.map(addr => addr.address)
@@ -40,6 +43,19 @@ function waitForWallet (party, currency, wallet) {
         usedAddresses.push(address)
       }
       addressesIndex += addressesPerCall
+    }
+
+    while (!unusedChangeAddressReached) {
+      let addresses = await client.getAddresses(changeAddressesIndex, addressesPerCall, true)
+      addresses = addresses.map(addr => addr.address)
+      for (const address of addresses) {
+        if (address === unusedChangeAddress) {
+          unusedChangeAddressReached = true
+          break
+        }
+        usedAddresses.push(address)
+      }
+      changeAddressesIndex += addressesPerCall
     }
 
     let allAddresses = [unusedAddress, ...usedAddresses]


### PR DESCRIPTION
### Description

Makes sure that the UI uses change and non change addresses when getting balance

### Parts

- [x] Include non change addresses when connecting wallet
