### PR TITLE
Button loading message: on initiation, claim and refund

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -1,8 +1,25 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import Spinner from './spinner.svg'
 import './Button.css'
 
 class Button extends Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      clickDisabled: false
+    }
+  }
+
+  onClickHandler (e) {
+    if (this.props.loadingAfterClickMessage) {
+      this.setState({
+        clickDisabled: true
+      })
+    }
+    this.props.onClick(e)
+  }
+
   render () {
     const classes = ['Button', 'btn']
 
@@ -23,9 +40,16 @@ class Button extends Component {
       classes.push('Button_small')
     }
 
-    return <button className={classes.join(' ')} disabled={this.props.disabled} onClick={e => this.props.onClick(e)}>
+    const showLoader = this.props.loadingAfterClick && this.state.clickDisabled
+    const disabled = this.state.clickDisabled || this.props.disabled
+
+    return <button className={classes.join(' ')} disabled={disabled} onClick={e => this.onClickHandler(e)}>
       {this.props.icon && <span class='Button_icon'><img src={this.props.icon} /></span>}
-      {this.props.children}
+      {showLoader &&
+        <img class='Button_spinner' src={Spinner} />
+      }
+      { this.props.loadingAfterClickMessage && this.state.clickDisabled
+        ? this.props.loadingAfterClickMessage : this.props.children }
     </button>
   }
 }
@@ -38,6 +62,8 @@ Button.propTypes = {
   small: PropTypes.bool,
   disabled: PropTypes.bool,
   icon: PropTypes.any,
+  loadingAfterClick: PropTypes.bool,
+  loadingAfterClickMessage: PropTypes.string,
   onClick: PropTypes.func
 }
 

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -24,6 +24,11 @@
       max-height: 20px;
     }
   }
+
+  &_spinner {
+    margin: -12px 10px -10px 0;
+    width: 26px;
+  }
 }
 
 .btn-secondary {

--- a/src/components/Button/spinner.svg
+++ b/src/components/Button/spinner.svg
@@ -1,0 +1,18 @@
+
+<!-- By Sam Herbert (@sherb), for everyone. More @ http://goo.gl/7AJzbL -->
+<svg width="38" height="38" viewBox="0 0 38 38" xmlns="http://www.w3.org/2000/svg" stroke="#fff">
+    <g fill="none" fill-rule="evenodd">
+        <g transform="translate(1 1)" stroke-width="2">
+            <circle stroke-opacity=".5" cx="18" cy="18" r="18"/>
+            <path d="M36 18c0-9.94-8.06-18-18-18">
+                <animateTransform
+                    attributeName="transform"
+                    type="rotate"
+                    from="0 18 18"
+                    to="360 18 18"
+                    dur="1s"
+                    repeatCount="indefinite"/>
+            </path>
+        </g>
+    </g>
+</svg>

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -14,5 +14,5 @@ export default {
     feeNumberOfBlocks: 2
   },
   debug: true,
-  injectFooter: `<p style="text-align: center;"><a href="https://github.com/liquality/chainabstractionlayer">Powered by ChainAbstractionLayer</a></p>`
+  injectFooter: `<p style="text-align: center;"><a href="https://github.com/liquality/chainabstractionlayer" target="_blank">Powered by ChainAbstractionLayer</a></p>`
 }

--- a/src/containers/SwapInitiation/SwapInitiation.js
+++ b/src/containers/SwapInitiation/SwapInitiation.js
@@ -73,8 +73,8 @@ class SwapInitiation extends Component {
         { this.props.isPartyB
           ? <ExpirationDetails />
           : <InitiatorExpirationInfo /> }
-        {!this.props.isPartyB && <Button wide primary disabled={!this.nextEnabled()} onClick={this.props.initiateSwap}>Next</Button>}
-        {this.props.isPartyB && <Button wide primary disabled={!this.nextEnabled()} onClick={this.props.confirmSwap}>Confirm Terms</Button>}
+        {!this.props.isPartyB && <Button wide primary disabled={!this.nextEnabled()} loadingAfterClickMessage='Check wallet for action' onClick={this.props.initiateSwap}>Next</Button>}
+        {this.props.isPartyB && <Button wide primary disabled={!this.nextEnabled()} loadingAfterClickMessage='Check wallet for action' onClick={this.props.confirmSwap}>Confirm Terms</Button>}
         <div class='SwapInitiation_errors'>
           {this.getErrors().map(error => <p>{error}</p>)}
         </div>

--- a/src/containers/SwapRedemption/SwapRedemption.js
+++ b/src/containers/SwapRedemption/SwapRedemption.js
@@ -16,7 +16,7 @@ class SwapRedemption extends Component {
         <p>Thanks to the <strong>Atomic Swap</strong> you don't need to trust the counterparty and avoid the middleman.</p>
       </div>
       <ExpirationDetails isClaim />
-      <p><Button wide primary onClick={this.props.redeemSwap}>Claim your funds</Button></p>
+      <p><Button wide primary loadingAfterClickMessage='Check wallet for action' onClick={this.props.redeemSwap}>Claim your funds</Button></p>
     </BrandCard>
   }
 }

--- a/src/containers/SwapRefund/SwapRefund.js
+++ b/src/containers/SwapRefund/SwapRefund.js
@@ -13,7 +13,7 @@ class SwapRedemption extends Component {
         </p>
         <p>Your funds are ready for a refund.</p>
       </div>
-      <p><Button wide primary onClick={this.props.refundSwap}>Get Refund</Button></p>
+      <p><Button wide primary loadingAfterClickMessage='Check wallet for action' onClick={this.props.refundSwap}>Get Refund</Button></p>
     </BrandCard>
   }
 }


### PR DESCRIPTION
### Description

* when confirming terms, button should only be clickable once and get an alert 
    * Disable button and show loader on button with message indicating “check wallet for action”


* when claiming terms, button should only be clickable once and get an alert that it is monitoring tx
    * Disable button and show loader on button with mess INDICATING “check wallet for action”

![image](https://user-images.githubusercontent.com/11529637/49938710-95866400-fed2-11e8-8e14-4f10953bcb67.png)

