### PR TITLE
Swap complete screen Ledger/MetaMask msg

### DIFF
--- a/src/containers/SwapCompleted/SwapCompleted.js
+++ b/src/containers/SwapCompleted/SwapCompleted.js
@@ -20,6 +20,9 @@ class SwapCompleted extends Component {
       <div class='SwapCompleted_top'>
         <CurrencyInputs disabled />
         <h2 class='SwapCompleted_label'>Swap Completed</h2>
+        <p class='SwapCompleted_subLabel'>
+          Go to {this.props.assets.b.currency === 'btc' ? 'Ledger Live' : 'MetaMask'} to confirm your balance
+        </p>
         <span class='SwapCompleted_handshake'><img src={HandshakeIcon} /></span>
       </div>
       <div class='SwapCompleted_bottom'>

--- a/src/containers/SwapCompleted/SwapCompleted.scss
+++ b/src/containers/SwapCompleted/SwapCompleted.scss
@@ -30,7 +30,7 @@
     left: -35px;
     border-radius: 50%;
     margin: auto;
-    z-index: $layer-top;
+    z-index: $layer-middle;
 
     img {
       width: 38px;
@@ -49,6 +49,15 @@
     top: $panel-spacing;
     text-align: center;
     color: $primary;
+  }
+
+  &_subLabel {
+    width: 100%;
+    position: absolute;
+    top: $panel-spacing + 35px;
+    text-align:center;
+    color: $primary;
+    z-index: $layer-top;
   }
 
   &_bottom {


### PR DESCRIPTION
### Description

This PR adds a message below Swap Completed getting a message to check their `Ledger Live` or `MetaMask` wallets

### Parts

- [ ] Check `Ledger Live` or `MetaMask` on Swap Completed

<img width="946" alt="screen shot 2018-12-13 at 10 58 08 am" src="https://user-images.githubusercontent.com/5362629/49950628-2b67c200-fec6-11e8-8409-86b6ba72d77e.png">