### PR TITLE
Strip 0x for eth

### DIFF
--- a/src/actions/counterparty.js
+++ b/src/actions/counterparty.js
@@ -3,6 +3,10 @@ const types = {
 }
 
 function changeCounterPartyAddress (currency, newValue, valid) {
+  if (currency === 'eth') {
+    newValue = newValue.startsWith('0x') ? newValue.slice(2) : newValue
+    newValue = newValue.toLowerCase()
+  }
   return { type: types.CHANGE_COUNTER_PARTY_ADDRESS, currency, newValue, valid }
 }
 

--- a/src/actions/counterparty.js
+++ b/src/actions/counterparty.js
@@ -4,7 +4,7 @@ const types = {
 
 function changeCounterPartyAddress (currency, newValue, valid) {
   if (currency === 'eth') {
-    newValue = newValue.startsWith('0x') ? newValue.slice(2) : newValue
+    newValue = newValue.replace('0x', '')
     newValue = newValue.toLowerCase()
   }
   return { type: types.CHANGE_COUNTER_PARTY_ADDRESS, currency, newValue, valid }

--- a/src/utils/currencies.js
+++ b/src/utils/currencies.js
@@ -21,7 +21,7 @@ const currencies = {
   'eth': {
     icon: ethIcon,
     code: 'ETH',
-    isValidAddress: address => /^[0-9a-fA-F]{40}$/.test(address),
+    isValidAddress: address => /^(0x)?[0-9a-fA-F]{40}$/.test(address),
     unitToCurrency (value) {
       return BigNumber(value).dividedBy(WEI_TO_ETH).toNumber()
     },


### PR DESCRIPTION
### Description

Strips 0x from eth addresses and lowerCases it to work with CAL at the UI level. This allows users to paste directly from MetaMask into the swap interface. 

### Parts

- [x] Strip 0x and lowerCase at `changeCounterPartyAddress` fn
