### PR TITLE
Logic for state and transactions + messaging

### DIFF
--- a/src/actions/swap.js
+++ b/src/actions/swap.js
@@ -149,7 +149,6 @@ function waitForSwapConfirmation () {
     dispatch(push('/waiting'))
     alphaWarning()
     await findInitiateSwapTransaction(dispatch, getState)
-    dispatch(push('/redeem'))
   }
 }
 
@@ -169,7 +168,6 @@ function waitForSwapClaim () {
     const claimTransaction = await client.findClaimSwapTransaction(transactions.a.fund.hash, counterParty[assets.a.currency].address, wallets.a.addresses[0], secretParams.secretHash, swapExpiration.unix())
     dispatch(secretActions.setSecret(claimTransaction.secret))
     dispatch(transactionActions.setTransaction('b', 'claim', claimTransaction))
-    dispatch(push('/redeem'))
   }
 }
 
@@ -204,7 +202,6 @@ async function unlockFunds (dispatch, getState) {
 function redeemSwap () {
   return async (dispatch, getState) => {
     await unlockFunds(dispatch, getState)
-    dispatch(push('/completed'))
   }
 }
 

--- a/src/components/ExpirationDetails/ExpirationDetails.js
+++ b/src/components/ExpirationDetails/ExpirationDetails.js
@@ -6,7 +6,6 @@ import { getClaimExpiration } from '../../utils/expiration'
 import withCopyButton from '../withCopyButton'
 import ClockIcon from '../../icons/clock.svg'
 import CopyIcon from '../../icons/copy.svg'
-import { steps } from '../SwapProgressStepper/steps'
 import './ExpirationDetails.css'
 
 class ExpirationDetails extends Component {
@@ -17,18 +16,15 @@ class ExpirationDetails extends Component {
 
   getTransaction () {
     const transactions = this.props.transactions
-    let displayOrder = [
+    const displayOrder = [
       transactions.b.claim,
-      transactions.a.claim,
-      transactions.b.fund,
-      transactions.a.fund
+      transactions.a.claim
     ]
 
-    if (this.props.step === steps.INITIATION || this.props.step === steps.AGREEMENT) {
-      displayOrder = [
-        transactions.a.fund,
-        transactions.b.fund
-      ]
+    if (this.props.isPartyB) {
+      displayOrder.push(transactions.a.fund, transactions.b.fund)
+    } else {
+      displayOrder.push(transactions.b.fund, transactions.a.fund)
     }
 
     return displayOrder.find(tx => tx.hash) || {}

--- a/src/containers/SwapInitiation/SwapInitiation.js
+++ b/src/containers/SwapInitiation/SwapInitiation.js
@@ -29,6 +29,10 @@ class SwapInitiation extends Component {
       this.props.counterParty[this.props.assets.b.currency].valid
   }
 
+  initiationExists () {
+    return this.props.isVerified && this.props.transactions.b.fund.hash
+  }
+
   initiationConfirmed () {
     return this.props.isVerified && this.props.transactions.b.fund.confirmations > 0
   }
@@ -42,14 +46,20 @@ class SwapInitiation extends Component {
     if (!this.walletsConnected()) {
       errors.push('Wallets are not connected')
     }
-    if (this.props.isPartyB && !this.walletsValid()) {
-      errors.push('The connected wallets must match the wallets supplied for the swap')
-    }
-    if (!this.props.isPartyB && !this.counterPartyAddressesValid()) {
-      errors.push('Invalid counter party addresses')
-    }
-    if (this.props.isPartyB && !this.initiationConfirmed()) {
-      errors.push('Counter party yet to lock funds')
+    if (this.props.isPartyB) {
+      if (!this.walletsValid()) {
+        errors.push('The connected wallets must match the wallets supplied for the swap')
+      }
+      if (!this.initiationExists()) {
+        errors.push('Counterparty hasn\'t initiated')
+      }
+      if (!this.initiationConfirmed()) {
+        errors.push('Counterparty has initiated, awaiting confirmations')
+      }
+    } else {
+      if (!this.counterPartyAddressesValid()) {
+        errors.push('Invalid counterparty addresses')
+      }
     }
     return errors
   }

--- a/src/containers/Waiting/Waiting.js
+++ b/src/containers/Waiting/Waiting.js
@@ -2,11 +2,34 @@ import React, { Component } from 'react'
 import BrandCard from '../../components/BrandCard/BrandCard'
 import ExpirationDetails from '../../components/ExpirationDetails'
 import LiqualityLogo from '../../logo.png'
+import { steps } from '../../components/SwapProgressStepper/steps'
 import './Waiting.css'
 
 class Waiting extends Component {
+  getWaitingStatus () {
+    if (this.props.step === steps.AGREEMENT) {
+      if (this.props.isPartyB) {
+        if (!this.props.transactions.b.claim.hash) {
+          return 'Counterparty hasn\'t claimed.'
+        }
+        if (!this.props.transactions.b.claim.confirmations > 0) {
+          return 'Counterparty has claimed. Awaiting confirmations.'
+        }
+      } else {
+        if (!this.props.transactions.b.fund.hash) {
+          return 'Counter hasn\'t confirmed terms.'
+        }
+        if (!this.props.transactions.b.fund.confirmations > 0) {
+          return 'Counterparty has confirmed terms. Awaiting confirmations.'
+        }
+      }
+    }
+    return ''
+  }
+
   render () {
     return <BrandCard className='Waiting' title='Awaiting Counterparty'>
+      <p class='Waiting_status'>{ this.getWaitingStatus() }</p>
       <p>Thanks to the Atomic Swap you don't need to trust the counterparty and avoid the middlemen.</p>
       <p><img className='LiqualitySwap_logo' src={LiqualityLogo} /></p>
       <ExpirationDetails isClaim />

--- a/src/containers/Waiting/Waiting.js
+++ b/src/containers/Waiting/Waiting.js
@@ -17,7 +17,7 @@ class Waiting extends Component {
         }
       } else {
         if (!this.props.transactions.b.fund.hash) {
-          return 'Counter hasn\'t confirmed terms.'
+          return 'Counterparty hasn\'t confirmed terms.'
         }
         if (!this.props.transactions.b.fund.confirmations > 0) {
           return 'Counterparty has confirmed terms. Awaiting confirmations.'

--- a/src/containers/Waiting/Waiting.scss
+++ b/src/containers/Waiting/Waiting.scss
@@ -1,3 +1,10 @@
+@import '../../scss/variables.scss';
+
 .Waiting {
   text-align: center;
+
+  &_status {
+    color: $primary;
+    font-size: $font-size-lg;
+  }
 }

--- a/src/containers/Waiting/index.js
+++ b/src/containers/Waiting/index.js
@@ -3,7 +3,9 @@ import Waiting from './Waiting'
 
 const mapStateToProps = state => {
   return {
+    step: state.swap.step,
     assets: state.swap.assets,
+    transactions: state.swap.transactions,
     expiration: state.swap.expiration,
     isPartyB: state.swap.isPartyB
   }


### PR DESCRIPTION
### Description

* A: no communication that B has confirmed terms, showing B's tx [Mempool check] 
    * Simple text that starts with “counterparty hasn't confirmed terms” and changes to “counterparty has confirmed terms, awaiting confirmations”

* B: once A has claimed, B should know that A has claimed and shown A's claim txID
    * Simple text that starts with “counterparty hasn't claimed” and changes to “counterparty has claimed, awaiting confirmations”