### PR TITLE
Update WalletChoose with testnet only for eth

### DIFF
--- a/src/components/WalletChoose/WalletChoose.js
+++ b/src/components/WalletChoose/WalletChoose.js
@@ -15,7 +15,7 @@ const WalletChoose = (props) => (
     {props.wallets.map((wallet) => (
       <div>
         <div class='WalletChoose_wallet'>
-          <p><a href='#'>Testnet only</a></p>
+          {props.currency === 'eth' && <p><a href='https://faucet.rinkeby.io/'>Testnet only</a></p>}
           <img src={wallets[wallet].icon} className='WalletPanel_walletImg' />
           <h5>{wallets[wallet].name}</h5>
           <p><a href='#'>Trouble connecting?</a></p>


### PR DESCRIPTION
### Description

This PR ensures `testnet only` only shows up on Ethereum `WalletConnect` component. 

### Parts

- [x] `Testnet only` only on Ethereum wallet connection 
