### PR TITLE
Ensure refund screen appears at correct time

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -29,10 +29,6 @@ const store = createStore(
 )
 
 if (initialAppState.swap) {
-  if (initialAppState.swap.transactions.a.fund.hash) {
-    store.dispatch(swapActions.waitForExpiration)
-  }
-
   if (initialAppState.swap.isPartyB) {
     // Need to use action to kick off tx monitoring
     store.dispatch(transactionActions.setTransaction(

--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,10 @@ import reducers from './reducers'
 import { generateSwapState } from './utils/app-links'
 import './App.css'
 
+window.onbeforeunload = () => { // Prompt on trying to leave app
+  return true
+}
+
 const history = createBrowserHistory({basename: window.location.pathname})
 
 hotjar.initialize(1102216, 6)

--- a/src/containers/LiqualitySwap/LiqualitySwap.js
+++ b/src/containers/LiqualitySwap/LiqualitySwap.js
@@ -24,7 +24,7 @@ class LiqualitySwap extends Component {
 
   getBackupLinkCard () {
     const link = this.props.swap.link
-    return <BackupLinkCard link={link} onNextClick={() => this.props.history.push(this.props.swap.isPartyB ? '/waiting' : '/counterPartyLink')} />
+    return <BackupLinkCard link={link} onNextClick={() => this.props.history.replace(this.props.swap.isPartyB ? '/waiting' : '/counterPartyLink')} />
   }
 
   getCounterPartyLinkCard () {


### PR DESCRIPTION
Ensure refund appears only when a claim has not happened and your funds are locked.

[x] - Prompt when use tries to navigate away from app - prevent them from leaving or refreshing easily
[x] - Tidy up setting the url