### PR TITLE
Fix wrong link on switch side

### DIFF
--- a/src/actions/wallets.js
+++ b/src/actions/wallets.js
@@ -38,7 +38,9 @@ function waitForWallet (party, currency, wallet) {
 
     const balance = await client.getBalance(allAddresses)
     const formattedBalance = currencies[currency].unitToCurrency(balance).toFixed(6)
-    dispatch(connectWallet(party, allAddresses, formattedBalance))
+    const otherParty = party === 'a' ? 'b' : 'a'
+    const walletParty = getState().swap.assets[party].currency === currency ? party : otherParty
+    dispatch(connectWallet(walletParty, allAddresses, formattedBalance))
   }
 }
 

--- a/src/reducers/wallets.js
+++ b/src/reducers/wallets.js
@@ -25,11 +25,6 @@ const initialState = {
 }
 
 function switchSides (state, action) {
-  if (state.b.chosen && !state.b.connected) {
-    state.b.switched = !state.b.switched
-  } else if (state.a.chosen && !state.a.connected) {
-    state.a.switched = !state.a.switched
-  }
   return update(state, {
     a: { $set: state.b },
     b: { $set: state.a }
@@ -55,10 +50,6 @@ function chooseWallet (state, action) {
 }
 
 function connectWallet (state, action) {
-  const otherParty = action.party === 'a' ? 'b' : 'a'
-  if (state[otherParty].switched) {
-    action.party = otherParty
-  }
   return update(state, {
     [action.party]: {
       addresses: { $set: action.addresses },

--- a/src/reducers/wallets.js
+++ b/src/reducers/wallets.js
@@ -10,6 +10,7 @@ const initialState = {
     connectOpen: false,
     connected: false,
     chosen: false,
+    switched: false,
     type: ''
   },
   b: {
@@ -18,11 +19,17 @@ const initialState = {
     connectOpen: false,
     connected: false,
     chosen: false,
+    switched: false,
     type: ''
   }
 }
 
 function switchSides (state, action) {
+  if (state.b.chosen && !state.b.connected) {
+    state.b.switched = !state.b.switched
+  } else if (state.a.chosen && !state.a.connected) {
+    state.a.switched = !state.a.switched
+  }
   return update(state, {
     a: { $set: state.b },
     b: { $set: state.a }
@@ -48,6 +55,10 @@ function chooseWallet (state, action) {
 }
 
 function connectWallet (state, action) {
+  const otherParty = action.party === 'a' ? 'b' : 'a'
+  if (state[otherParty].switched) {
+    action.party = otherParty
+  }
   return update(state, {
     [action.party]: {
       addresses: { $set: action.addresses },

--- a/src/reducers/wallets.js
+++ b/src/reducers/wallets.js
@@ -10,7 +10,6 @@ const initialState = {
     connectOpen: false,
     connected: false,
     chosen: false,
-    switched: false,
     type: ''
   },
   b: {
@@ -19,7 +18,6 @@ const initialState = {
     connectOpen: false,
     connected: false,
     chosen: false,
-    switched: false,
     type: ''
   }
 }


### PR DESCRIPTION
### Description

This PR addresses the problem when a user is connecting their ledger, and they switch sides, causing the state to be updated for the wrong party, resulting in an incorrect counterparty link. 
