### PR TITLE
Mininum confirmations config

### DIFF
--- a/src/actions/transactions.js
+++ b/src/actions/transactions.js
@@ -1,6 +1,7 @@
 import { replace } from 'connected-react-router'
 import _ from 'lodash'
 import moment from 'moment'
+import config from '../config'
 import { actions as swapActions } from './swap'
 import { actions as secretActions } from './secretparams'
 import { steps } from '../components/SwapProgressStepper/steps'
@@ -25,8 +26,8 @@ function setStep (transactions, isPartyB, dispatch) {
   if (transactions.a.fund.hash) {
     step = steps.AGREEMENT
     if (transactions.b.fund.hash) {
-      if (transactions.a.fund.confirmations >= 0 && transactions.b.fund.confirmations >= 0) {
-        if (transactions.b.claim.confirmations >= 0 || !isPartyB) {
+      if (transactions.a.fund.confirmations >= config.minConfirmations && transactions.b.fund.confirmations >= config.minConfirmations) {
+        if (transactions.b.claim.confirmations >= config.minConfirmations || !isPartyB) {
           step = steps.CLAIMING
         }
         if (transactions.a.claim.hash) {

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -2,5 +2,6 @@ export default {
   injectScript: '',
   injectFooter: '',
   debug: false,
-  twitterButton: false
+  twitterButton: false,
+  minConfirmations: 1
 }

--- a/src/containers/SwapInitiation/SwapInitiation.js
+++ b/src/containers/SwapInitiation/SwapInitiation.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 
+import config from '../../config'
 import WalletPanel from '../WalletPanel'
 import SwapPairPanel from '../../components/SwapPairPanel/SwapPairPanel'
 import CurrencyInputs from '../CurrencyInputs'
@@ -34,7 +35,7 @@ class SwapInitiation extends Component {
   }
 
   initiationConfirmed () {
-    return this.props.isVerified && this.props.transactions.b.fund.confirmations >= 0
+    return this.props.isVerified && this.props.transactions.b.fund.confirmations >= config.minConfirmations
   }
 
   nextEnabled () {


### PR DESCRIPTION
### Description

For security reasons the default minimum confirmations to progress swaps should be 1 however we should still allow it to be configurable for 0 or many depending on preference.

Of course a global min confs doesn't make much sense given difference security properties per chain. This is just as a global default. In the future this config should be per chain too.

### Parts

- [x] Add minConfirmations config 
- [x] Default minConfirmations to 1
