### PR TITLE
Fix party B rate calculation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import errorHandler from './errorHandler'
 
 import { actions as swapActions } from './actions/swap'
 import { actions as transactionActions } from './actions/transactions'
+import { actions as assetActions } from './actions/assets'
 
 import LiqualitySwap from './containers/LiqualitySwap'
 import './App.css'
@@ -28,6 +29,7 @@ if (initialAppState.swap) {
       'b', 'fund', initialAppState.swap.transactions.b.fund
     ))
     store.dispatch(swapActions.verifyInitiateSwapTransaction)
+    store.dispatch(assetActions.changeAmount('b', initialAppState.swap.assets.b.value)) // Trigger rate calc
   }
 }
 

--- a/src/actions/assets.js
+++ b/src/actions/assets.js
@@ -1,5 +1,18 @@
 const types = {
-  CHANGE_AMOUNT: 'CHANGE_AMOUNT'
+  CHANGE_AMOUNT: 'CHANGE_AMOUNT',
+  CHANGE_RATE: 'CHANGE_RATE'
+}
+
+function changeRate (newValue) {
+  return (dispatch, getState) => {
+    dispatch({ type: types.CHANGE_RATE, newValue })
+    const { assets } = getState().swap
+    const a = {type: 'a', value: assets.a.value || 0}
+    const rate = assets.rate || 0
+
+    let newVal = +(parseFloat(a.value) * parseFloat(rate)).toFixed(6)
+    dispatch({ type: types.CHANGE_AMOUNT, party: 'b', newValue: newVal.toString() })
+  }
 }
 
 function changeAmount (party, newValue) {
@@ -9,25 +22,26 @@ function changeAmount (party, newValue) {
 
     const a = {type: 'a', value: assets.a.value || 0}
     const b = {type: 'b', value: assets.b.value || 0}
-    const rate = {type: 'rate', value: assets.rate.value || 0}
+    const rate = assets.rate || 0
 
-    if (party === 'a' || party === 'rate') {
-      let newVal = +(parseFloat(a.value) * parseFloat(rate.value)).toFixed(6)
+    if (party === 'a') {
+      let newVal = +(parseFloat(a.value) * parseFloat(rate)).toFixed(6)
       dispatch({ type: types.CHANGE_AMOUNT, party: 'b', newValue: newVal.toString() })
     } else if (party === 'b') {
       if (a.value === 0) {
         let newVal = +(parseFloat(b.value) * parseFloat(rate.value)).toFixed(6)
         dispatch({ type: types.CHANGE_AMOUNT, party: 'a', newValue: newVal.toString() })
       } else {
-        let newVal = +(parseFloat(b.value) / parseFloat(a.value)).toFixed(6)
-        dispatch({ type: types.CHANGE_AMOUNT, party: 'rate', newValue: newVal.toString() })
+        let newRate = +(parseFloat(b.value) / parseFloat(a.value)).toFixed(6)
+        dispatch({ type: types.CHANGE_RATE, newValue: newRate.toString() })
       }
     }
   }
 }
 
 const actions = {
-  changeAmount
+  changeAmount,
+  changeRate
 }
 
 export { types, actions }

--- a/src/containers/CurrencyInputs/CurrencyInputs.js
+++ b/src/containers/CurrencyInputs/CurrencyInputs.js
@@ -34,10 +34,10 @@ class CurrencyInputs extends Component {
             <Rate
               currencyA={assetA.currency}
               currencyB={assetB.currency}
-              value={assetRate.value}
+              value={assetRate}
               disabled={this.props.disabled}
               error={errors.rate}
-              onChange={newValueA => this.props.onAmountChange('rate', newValueA)}
+              onChange={newValueA => this.props.onRateChange(newValueA)}
               tabIndex={2}
             />
           </div>

--- a/src/containers/CurrencyInputs/index.js
+++ b/src/containers/CurrencyInputs/index.js
@@ -15,6 +15,7 @@ export default connect(
   mapStateToProps,
   {
     onSwitchSides: swapActions.switchSides,
-    onAmountChange: assetActions.changeAmount
+    onAmountChange: assetActions.changeAmount,
+    onRateChange: assetActions.changeRate
   }
 )(CurrencyInputs)

--- a/src/reducers/assets.js
+++ b/src/reducers/assets.js
@@ -12,9 +12,7 @@ const initialState = {
     currency: 'btc',
     value: ''
   },
-  rate: {
-    value: ''
-  }
+  rate: ''
 }
 
 function switchSides (state, action) {
@@ -22,7 +20,7 @@ function switchSides (state, action) {
   return update(state, {
     a: { $set: state.b },
     b: { $set: state.a },
-    rate: { $set: { value: newRate.toString() } }
+    rate: { $set: newRate.toString() }
   })
 }
 
@@ -32,9 +30,16 @@ function changeAmount (state, action) {
   })
 }
 
+function changeRate (state, action) {
+  return update(state, {
+    rate: { $set: action.newValue }
+  })
+}
+
 const reducers = {
   [swapTypes.SWITCH_SIDES]: switchSides,
-  [assetTypes.CHANGE_AMOUNT]: changeAmount
+  [assetTypes.CHANGE_AMOUNT]: changeAmount,
+  [assetTypes.CHANGE_RATE]: changeRate
 }
 
 const assets = getReducerFunction(reducers, initialState)

--- a/src/utils/app-links.js
+++ b/src/utils/app-links.js
@@ -4,14 +4,14 @@ import moment from 'moment'
 const APP_BASE_URL = `${window.location.protocol}//${window.location.host}${window.location.pathname}`
 
 function generateLink (swap, counterparty = false) {
-  let assetA, assetB, assetRate, walletA, walletB, transactionsA, transactionsB
+  let assetA, assetB, walletA, walletB, transactionsA, transactionsB
 
   if (counterparty) { // Switch around sides as this will be the state of the counter party
-    ({ a: assetB, b: assetA, rate: assetRate } = swap.assets)
+    ({ a: assetB, b: assetA } = swap.assets)
     ;({ a: walletB, b: walletA } = swap.wallets)
     ;({ a: transactionsB, b: transactionsA } = swap.transactions)
   } else {
-    ({ a: assetA, b: assetB, rate: assetRate } = swap.assets)
+    ({ a: assetA, b: assetB } = swap.assets)
     ;({ a: walletA, b: walletB } = swap.wallets)
     ;({ a: transactionsA, b: transactionsB } = swap.transactions)
   }
@@ -26,8 +26,6 @@ function generateLink (swap, counterparty = false) {
     ccy2v: assetB.value,
     ccy2Addr: counterparty ? swap.counterParty[assetB.currency].address : walletB.addresses[0],
     ccy2CounterPartyAddr: counterparty ? walletB.addresses[0] : swap.counterParty[assetB.currency].address,
-
-    ccy3v: assetRate.value,
 
     aFundHash: transactionsA.fund.hash,
     bFundHash: transactionsB.fund.hash,
@@ -52,8 +50,7 @@ function generateSwapState (location) {
   return {
     assets: {
       a: { currency: urlParams.ccy1, value: parseFloat(urlParams.ccy1v) },
-      b: { currency: urlParams.ccy2, value: parseFloat(urlParams.ccy2v) },
-      rate: { value: parseFloat(urlParams.ccy3v) }
+      b: { currency: urlParams.ccy2, value: parseFloat(urlParams.ccy2v) }
     },
     wallets: {
       a: { addresses: [urlParams.ccy1Addr] },

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -7,7 +7,7 @@ function getCurrencyInputErrors (assets) {
   const { a: assetA, b: assetB, rate: assetRate } = assets
   if (!(assetA.value > 0)) errors.assetA = 'Amount not set'
   if (!(assetB.value > 0)) errors.assetB = 'Amount not set'
-  if (!(assetRate.value > 0)) errors.rate = 'Please select the conversion rate'
+  if (!(assetRate > 0)) errors.rate = 'Please select the conversion rate'
   return errors
 }
 


### PR DESCRIPTION
Party B's rate was being passed in the URL. This would make it not correct since the sides are reversed for PartyB. 
This PR refactors the logic to remove rate from URL and calculate it for party B upon opening the app.