### PR TITLE
Prevent confirm and claim when offer has expired (unsafe)

### DIFF
--- a/src/components/ExpirationDetails/ExpirationDetails.js
+++ b/src/components/ExpirationDetails/ExpirationDetails.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import moment from 'moment'
 import cryptoassets from '@liquality/cryptoassets'
-import { getClaimExpiration } from '../../utils/expiration'
+import { getFundExpiration, getClaimExpiration } from '../../utils/expiration'
 import withCopyButton from '../withCopyButton'
 import ClockIcon from '../../icons/clock.svg'
 import CopyIcon from '../../icons/copy.svg'
@@ -32,7 +32,7 @@ class ExpirationDetails extends Component {
 
   getExpirationState () {
     const party = this.props.isPartyB ? 'b' : 'a'
-    const expiration = getClaimExpiration(this.props.expiration, party)
+    const expiration = this.props.isClaim ? getClaimExpiration(this.props.expiration, party) : getFundExpiration(this.props.expiration, party)
     return {
       start: expiration.start,
       duration: expiration.duration,

--- a/src/containers/SwapInitiation/SwapInitiation.js
+++ b/src/containers/SwapInitiation/SwapInitiation.js
@@ -18,7 +18,7 @@ class SwapInitiation extends Component {
   render () {
     const wallet = wallets[this.props.wallets.a.type]
     const buttonLoadingMessage = wallet && `Confirm on ${wallet.name}`
-    const errors = getInitiationErrors(this.props.transactions, this.props.isVerified, this.props.isPartyB)
+    const errors = getInitiationErrors(this.props.transactions, this.props.expiration, this.props.isVerified, this.props.isPartyB)
 
     return <div className='SwapInitiation'>
       <SwapPairPanel
@@ -40,9 +40,9 @@ class SwapInitiation extends Component {
           : <InitiatorExpirationInfo /> }
         {!errors.initiation && !this.props.isPartyB && <Button wide primary loadingAfterClick loadingAfterClickMessage={buttonLoadingMessage} onClick={this.props.initiateSwap}>Initiate Swap</Button>}
         {!errors.initiation && this.props.isPartyB && <Button wide primary loadingAfterClick loadingAfterClickMessage={buttonLoadingMessage} onClick={this.props.confirmSwap}>Confirm Terms</Button>}<br />
+        {errors.initiation && <div className='SwapInitiation_errorMessage'>{errors.initiation}</div>}
         {/* TODO: Do actual resetting of app state instead of refresh. */}
         <Button wide link onClick={() => window.location.replace(APP_BASE_URL)}>{ this.props.isPartyB ? 'Abandon Swap' : 'Cancel' }</Button>
-        {errors.initiation && <div className='SwapInitiation_errorMessage'>{errors.initiation}</div>}
       </div>
     </div>
   }

--- a/src/containers/SwapRedemption/SwapRedemption.js
+++ b/src/containers/SwapRedemption/SwapRedemption.js
@@ -3,12 +3,14 @@ import BrandCard from '../../components/BrandCard/BrandCard'
 import Button from '../../components/Button/Button'
 import cryptoassets from '@liquality/cryptoassets'
 import { wallets } from '../../utils/wallets'
+import { getClaimErrors } from '../../utils/validation'
 import ExpirationDetails from '../../components/ExpirationDetails'
 
 import './SwapRedemption.css'
 
 class SwapRedemption extends Component {
   render () {
+    const errors = getClaimErrors(this.props.expiration, this.props.isPartyB)
     const wallet = wallets[this.props.wallets.b.type]
     const buttonLoadingMessage = wallet && `Confirm on ${wallet.name}`
 
@@ -21,7 +23,10 @@ class SwapRedemption extends Component {
         <p>Thanks to the <strong>Atomic Swap</strong> you don't need to trust the counterparty and avoid the middleman.</p>
       </div>
       <ExpirationDetails isClaim />
-      <p><Button wide primary loadingAfterClick loadingAfterClickMessage={buttonLoadingMessage} onClick={this.props.redeemSwap}>Claim your funds</Button></p>
+      <p>
+        {!errors.claim && <Button wide primary loadingAfterClick loadingAfterClickMessage={buttonLoadingMessage} onClick={this.props.redeemSwap}>Claim your funds</Button>}
+        {errors.claim && <div className='SwapRedemption_errorMessage'>{errors.claim}</div>}
+      </p>
     </BrandCard>
   }
 }

--- a/src/containers/SwapRedemption/SwapRedemption.scss
+++ b/src/containers/SwapRedemption/SwapRedemption.scss
@@ -1,10 +1,15 @@
 @import '../../scss/variables.scss';
+@import '../../scss/mixins.scss';
 
 .SwapRedemption {
   text-align: center;
 
   &_terms {
     font-size: $h1-font-size;
+  }
+
+  &_errorMessage {
+    @include error-message;
   }
 
   .ExpirationDetails {


### PR DESCRIPTION
### Description

When the timer for locking funds has run out, confirming terms should not be enabled for party B. This can cause a situation where party A will not have enough time to claim.
Similarly, when claiming, the claim button should not be active when the counter party is able to refund. This is to prevent one party ending up with both balances.
