### PR TITLE
Wallet con continue flow

### DIFF
--- a/src/actions/swap.js
+++ b/src/actions/swap.js
@@ -81,13 +81,13 @@ async function ensureSecret (dispatch, getState) {
   const {
     secretParams,
     assets,
-    wallets,
     counterParty,
     isPartyB,
     expiration
   } = getState().swap
   if (!isPartyB && !secretParams.secret) {
     await ensureWallet('a', dispatch, getState)
+    const { wallets } = getState().swap
     const client = getClient(assets.a.currency, wallets.a.type)
     const secretData = [
       assets.a.value,

--- a/src/actions/swap.js
+++ b/src/actions/swap.js
@@ -7,6 +7,7 @@ import { actions as transactionActions } from './transactions'
 import { actions as secretActions } from './secretparams'
 import { actions as walletActions } from './wallets'
 import cryptoassets from '@liquality/cryptoassets'
+import { wallets as walletsConfig } from '../utils/wallets'
 import { sleep } from '../utils/async'
 import { getFundExpiration, getClaimExpiration, generateExpiration } from '../utils/expiration'
 import { isInitiateValid } from '../utils/validation'
@@ -17,7 +18,8 @@ const types = {
   SET_EXPIRATION: 'SET_EXPIRATION',
   SET_LINK: 'SET_LINK',
   SET_IS_VERIFIED: 'SET_IS_VERIFIED',
-  SET_SHOW_ERRORS: 'SET_SHOW_ERRORS'
+  SET_SHOW_ERRORS: 'SET_SHOW_ERRORS',
+  SET_LOADING_MESSAGE: 'SET_LOADING_MESSAGE'
 }
 
 function switchSides () {
@@ -46,6 +48,14 @@ function showErrors () {
 
 function hideErrors () {
   return { type: types.SET_SHOW_ERRORS, showErrors: false }
+}
+
+function setLoadingMessage (loadingMessage) {
+  return { type: types.SET_LOADING_MESSAGE, loadingMessage: loadingMessage }
+}
+
+function clearLoadingMessage () {
+  return { type: types.SET_LOADING_MESSAGE, loadingMessage: null }
 }
 
 async function ensureWallet (party, dispatch, getState) {
@@ -101,8 +111,10 @@ async function ensureSecret (dispatch, getState) {
       expiration.unix()
     ]
     const secretMsg = secretData.join('')
-    const secret = await client.generateSecret(secretMsg)
-    dispatch(secretActions.setSecret(secret))
+    await withLoadingMessage('a', dispatch, getState, async () => {
+      const secret = await client.generateSecret(secretMsg)
+      dispatch(secretActions.setSecret(secret))
+    })
   }
 }
 
@@ -135,6 +147,17 @@ async function lockFunds (dispatch, getState) {
   dispatch(transactionActions.setTransaction('a', 'fund', { hash: txHash, block }))
 }
 
+async function withLoadingMessage (party, dispatch, getState, func) {
+  const wallets = getState().swap.wallets
+  const wallet = walletsConfig[wallets[party].type]
+  dispatch(setLoadingMessage(`Confirm on ${wallet.name}`))
+  try {
+    await func(dispatch, getState)
+  } finally {
+    dispatch(clearLoadingMessage())
+  }
+}
+
 function initiateSwap () {
   return async (dispatch, getState) => {
     dispatch(showErrors())
@@ -145,7 +168,9 @@ function initiateSwap () {
     const initiateValid = isInitiateValid(getState().swap)
     if (!initiateValid) return
     await ensureSecret(dispatch, getState)
-    await lockFunds(dispatch, getState)
+    await withLoadingMessage('a', dispatch, getState, async () => {
+      await lockFunds(dispatch, getState)
+    })
     dispatch(setIsVerified(true))
     dispatch(replace('/backupLink'))
   }
@@ -158,7 +183,7 @@ function confirmSwap () {
     await ensureWallet('b', dispatch, getState)
     const initiateValid = isInitiateValid(getState().swap)
     if (!initiateValid) return
-    await lockFunds(dispatch, getState)
+    await withLoadingMessage('a', dispatch, getState, lockFunds)
     dispatch(waitForSwapClaim())
     dispatch(replace('/backupLink'))
   }
@@ -260,7 +285,7 @@ function redeemSwap () {
   return async (dispatch, getState) => {
     await ensureSecret(dispatch, getState)
     await ensureWallet('b', dispatch, getState)
-    await unlockFunds(dispatch, getState)
+    await withLoadingMessage('b', dispatch, getState, unlockFunds)
   }
 }
 
@@ -280,13 +305,15 @@ function refundSwap () {
 
     const client = getClient(assets.a.currency, wallets.a.type)
     const swapExpiration = getFundExpiration(expiration, isPartyB ? 'b' : 'a').time
-    await client.refundSwap(
-      transactions.a.fund.hash,
-      counterParty.a.address,
-      wallets.a.addresses[0],
-      secretParams.secretHash,
-      swapExpiration.unix()
-    )
+    await withLoadingMessage('a', dispatch, getState, async () => {
+      return client.refundSwap(
+        transactions.a.fund.hash,
+        counterParty.a.address,
+        wallets.a.addresses[0],
+        secretParams.secretHash,
+        swapExpiration.unix()
+      )
+    })
   }
 }
 

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -4,29 +4,6 @@ import Spinner from './spinner.svg'
 import './Button.css'
 
 class Button extends Component {
-  constructor (props) {
-    super(props)
-    this.state = {
-      clickDisabled: false
-    }
-  }
-
-  onClickHandler (e) {
-    if (this.props.loadingAfterClickMessage) {
-      this.setState({
-        clickDisabled: true
-      })
-      this.timeout = setTimeout(() => {
-        this.setState({clickDisabled: false})
-      }, 20000)
-    }
-    this.props.onClick(e)
-  }
-
-  componentWillUnmount () {
-    clearTimeout(this.timeout)
-  }
-
   render () {
     const classes = ['Button', 'btn']
 
@@ -49,16 +26,15 @@ class Button extends Component {
       classes.push('Button_small')
     }
 
-    const showLoader = this.props.loadingAfterClick && this.state.clickDisabled
-    const disabled = this.state.clickDisabled || this.props.disabled
+    const showLoader = this.props.loadingMessage
+    const disabled = this.props.disabled || this.props.loadingMessage
 
-    return <button tabIndex={this.props.tabIndex} className={classes.join(' ')} disabled={disabled} onClick={e => this.onClickHandler(e)}>
+    return <button tabIndex={this.props.tabIndex} className={classes.join(' ')} disabled={disabled} onClick={e => this.props.onClick(e)}>
       {this.props.icon && <span className='Button_icon'><img src={this.props.icon} alt='' /></span>}
-      {showLoader &&
+      { showLoader &&
         <img className='Button_spinner' src={Spinner} alt='Loading...' />
       }
-      { this.props.loadingAfterClickMessage && this.state.clickDisabled
-        ? this.props.loadingAfterClickMessage : this.props.children }
+      { showLoader ? this.props.loadingMessage : this.props.children }
     </button>
   }
 }
@@ -73,8 +49,7 @@ Button.propTypes = {
   disabled: PropTypes.bool,
   icon: PropTypes.any,
   onClick: PropTypes.func,
-  loadingAfterClick: PropTypes.bool,
-  loadingAfterClickMessage: PropTypes.string,
+  loadingMessage: PropTypes.string,
   tabIndex: PropTypes.number
 }
 

--- a/src/containers/SwapInitiation/SwapInitiation.js
+++ b/src/containers/SwapInitiation/SwapInitiation.js
@@ -10,14 +10,11 @@ import CurrencyInputs from '../CurrencyInputs'
 import InitiatorExpirationInfo from '../InitiatorExpirationInfo'
 import WalletPanel from '../WalletPanel'
 import './SwapInitiation.css'
-import { wallets } from '../../utils/wallets'
 import { getInitiationErrors } from '../../utils/validation'
 import { APP_BASE_URL } from '../../utils/app-links'
 
 class SwapInitiation extends Component {
   render () {
-    const wallet = wallets[this.props.wallets.a.type]
-    const buttonLoadingMessage = wallet && `Confirm on ${wallet.name}`
     const errors = getInitiationErrors(this.props.transactions, this.props.expiration, this.props.isVerified, this.props.isPartyB)
 
     return <div className='SwapInitiation'>
@@ -38,8 +35,8 @@ class SwapInitiation extends Component {
         { this.props.isPartyB
           ? <ExpirationDetails />
           : <InitiatorExpirationInfo /> }
-        {!errors.initiation && !this.props.isPartyB && <Button wide primary loadingAfterClick loadingAfterClickMessage={buttonLoadingMessage} onClick={this.props.initiateSwap}>Initiate Swap</Button>}
-        {!errors.initiation && this.props.isPartyB && <Button wide primary loadingAfterClick loadingAfterClickMessage={buttonLoadingMessage} onClick={this.props.confirmSwap}>Confirm Terms</Button>}<br />
+        {!errors.initiation && !this.props.isPartyB && <Button wide primary loadingMessage={this.props.loadingMessage} onClick={this.props.initiateSwap}>Initiate Swap</Button>}
+        {!errors.initiation && this.props.isPartyB && <Button wide primary loadingMessage={this.props.loadingMessage} onClick={this.props.confirmSwap}>Confirm Terms</Button>}<br />
         {errors.initiation && <div className='SwapInitiation_errorMessage'>{errors.initiation}</div>}
         {/* TODO: Do actual resetting of app state instead of refresh. */}
         <Button wide link onClick={() => window.location.replace(APP_BASE_URL)}>{ this.props.isPartyB ? 'Abandon Swap' : 'Cancel' }</Button>

--- a/src/containers/SwapInitiation/index.js
+++ b/src/containers/SwapInitiation/index.js
@@ -12,7 +12,8 @@ const mapStateToProps = state => {
     assets: state.swap.assets,
     counterParty: state.swap.counterParty,
     transactions: state.swap.transactions,
-    isVerified: state.swap.isVerified
+    isVerified: state.swap.isVerified,
+    loadingMessage: state.swap.loadingMessage
   }
 }
 

--- a/src/containers/SwapRedemption/SwapRedemption.js
+++ b/src/containers/SwapRedemption/SwapRedemption.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react'
 import BrandCard from '../../components/BrandCard/BrandCard'
 import Button from '../../components/Button/Button'
 import cryptoassets from '@liquality/cryptoassets'
-import { wallets } from '../../utils/wallets'
 import { getClaimErrors } from '../../utils/validation'
 import ExpirationDetails from '../../components/ExpirationDetails'
 
@@ -11,8 +10,6 @@ import './SwapRedemption.css'
 class SwapRedemption extends Component {
   render () {
     const errors = getClaimErrors(this.props.expiration, this.props.isPartyB)
-    const wallet = wallets[this.props.wallets.b.type]
-    const buttonLoadingMessage = wallet && `Confirm on ${wallet.name}`
 
     return <BrandCard className='SwapRedemption' title='Claim Funds'>
       <div className='SwapRedemption_confirmation'>
@@ -24,7 +21,7 @@ class SwapRedemption extends Component {
       </div>
       <ExpirationDetails isClaim />
       <p>
-        {!errors.claim && <Button wide primary loadingAfterClick loadingAfterClickMessage={buttonLoadingMessage} onClick={this.props.redeemSwap}>Claim your funds</Button>}
+        {!errors.claim && <Button wide primary loadingMessage={this.props.loadingMessage} onClick={this.props.redeemSwap}>Claim your funds</Button>}
         {errors.claim && <div className='SwapRedemption_errorMessage'>{errors.claim}</div>}
       </p>
     </BrandCard>

--- a/src/containers/SwapRedemption/index.js
+++ b/src/containers/SwapRedemption/index.js
@@ -7,7 +7,8 @@ const mapStateToProps = state => {
     assets: state.swap.assets,
     wallets: state.swap.wallets,
     expiration: state.swap.expiration,
-    isPartyB: state.swap.isPartyB
+    isPartyB: state.swap.isPartyB,
+    loadingMessage: state.swap.loadingMessage
   }
 }
 

--- a/src/containers/SwapRefund/SwapRefund.js
+++ b/src/containers/SwapRefund/SwapRefund.js
@@ -2,14 +2,10 @@ import React, { Component } from 'react'
 import BrandCard from '../../components/BrandCard/BrandCard'
 import Button from '../../components/Button/Button'
 import cryptoassets from '@liquality/cryptoassets'
-import { wallets } from '../../utils/wallets'
 import './SwapRefund.css'
 
 class SwapRedemption extends Component {
   render () {
-    const wallet = wallets[this.props.wallets.a.type]
-    const buttonLoadingMessage = wallet && `Confirm on ${wallet.name}`
-
     return <BrandCard className='SwapRefund' title='Refund'>
       <div className='SwapRefund_confirmation'>
         <p className='SwapRefund_terms'>
@@ -17,7 +13,7 @@ class SwapRedemption extends Component {
         </p>
         <p>Your funds are ready for a refund.</p>
       </div>
-      <p><Button wide primary loadingAfterClick loadingAfterClickMessage={buttonLoadingMessage} onClick={this.props.refundSwap}>Get Refund</Button></p>
+      <p><Button wide primary loadingMessage={this.props.loadingMessage} onClick={this.props.refundSwap}>Get Refund</Button></p>
     </BrandCard>
   }
 }

--- a/src/containers/SwapRefund/index.js
+++ b/src/containers/SwapRefund/index.js
@@ -7,7 +7,8 @@ const mapStateToProps = state => {
     assets: state.swap.assets,
     wallets: state.swap.wallets,
     expiration: state.swap.expiration,
-    isPartyB: state.swap.isPartyB
+    isPartyB: state.swap.isPartyB,
+    loadingMessage: state.swap.loadingMessage
   }
 }
 

--- a/src/reducers/swap.js
+++ b/src/reducers/swap.js
@@ -32,5 +32,8 @@ export default combineReducers({
   showErrors: (state = false, action) => {
     return action.type === types.SET_SHOW_ERRORS ? action.showErrors : state
   },
+  loadingMessage: (state = null, action) => {
+    return action.type === types.SET_LOADING_MESSAGE ? action.loadingMessage : state
+  },
   isPartyB: (state = false) => state
 })


### PR DESCRIPTION
### Description

When the action buttons (initiate, confirm, redeem etc.) are pressed, they display a loading spinner for 20 seconds regardless of what the user has done. 
With this fix, the button only goes into this loading state while the user needs to perform an action on the wallet.

![image](https://user-images.githubusercontent.com/11529637/57541285-88b55180-7346-11e9-950f-f1cbe96b6b41.png)


### Parts

- [x] Set button loading message only when action required
- [x] Get latest wallet selected when generating secret (fixes bug)