### PR TITLE
fix: add timeouts to redeem and claim buttons

### DIFF
--- a/src/containers/SwapRedemption/SwapRedemption.js
+++ b/src/containers/SwapRedemption/SwapRedemption.js
@@ -8,6 +8,25 @@ import TransactionDetails from '../../components/TransactionDetails'
 import './SwapRedemption.css'
 
 class SwapRedemption extends Component {
+  constructor (props) {
+    super(props)
+
+    this.redeemButtonState = true // active by default
+    this.redeemButtonClickWithTimeout = this.redeemButtonClickWithTimeout.bind(this)
+  }
+
+  redeemButtonClickWithTimeout () {
+    if (this.redeemButtonState) {
+      this.redeemButtonState = false // inactive
+
+      this.props.redeemSwap()
+
+      setTimeout(() => {
+        this.redeemButtonState = true // reactive it
+      }, 2000)
+    }
+  }
+
   render () {
     const errors = getClaimErrors(this.props.transactions, this.props.isPartyB)
     const claimCurrency = cryptoassets[this.props.assets.b.currency]
@@ -20,7 +39,7 @@ class SwapRedemption extends Component {
           Connect the account that you provided as <br /> {claimCurrency.code} receiving address
           </p>
           <p className='SwapRedemption_buttonWrap'>
-            {!errors.claim && <Button className='SwapRedemption_claimButton mt-5' wide primary loadingMessage={this.props.loadingMessage} onClick={() => this.props.redeemSwap()}>Claim {this.props.assets.b.value.toFixed()} {claimCurrency.code}</Button>}
+            {!errors.claim && <Button disabled={!this.redeemButtonState} className='SwapRedemption_claimButton mt-5' wide primary loadingMessage={this.props.loadingMessage} onClick={() => this.redeemButtonClickWithTimeout}>Claim {this.props.assets.b.value.toFixed()} {claimCurrency.code}</Button>}
             {errors.claim && <div className='SwapRedemption_errorMessage'>{errors.claim}</div>}
           </p>
         </div>

--- a/src/containers/SwapRefund/SwapRefund.js
+++ b/src/containers/SwapRefund/SwapRefund.js
@@ -5,6 +5,25 @@ import { assets as cryptoassets } from '@liquality/cryptoassets'
 import './SwapRefund.css'
 
 class SwapRedemption extends Component {
+  constructor (props) {
+    super(props)
+
+    this.claimButtonState = true // active by default
+    this.claimButtonClickWithTimeout = this.claimButtonClickWithTimeout.bind(this)
+  }
+
+  claimButtonClickWithTimeout () {
+    if (this.claimButtonState) {
+      this.claimButtonState = false // inactive
+
+      this.props.refundSwap()
+
+      setTimeout(() => {
+        this.claimButtonState = true // reactive it
+      }, 2000)
+    }
+  }
+
   render () {
     return <div>
       <BrandCard className='SwapRefund' title='RECLAIM YOUR ASSETS'>
@@ -15,7 +34,7 @@ class SwapRedemption extends Component {
           </p>
           <p>To process this refund, press the reclaim button.</p>
         </div>
-        <p><Button wide primary loadingMessage={this.props.loadingMessage} onClick={this.props.refundSwap}>Reclaim</Button></p>
+        <p><Button disabled={!this.claimButtonState} wide primary loadingMessage={this.props.loadingMessage} onClick={this.claimButtonClickWithTimeout}>Reclaim</Button></p>
         <div className='SwapRefund_expiredFrame'>
           <div className='SwapRefund_expiredFrame_content'>
 


### PR DESCRIPTION
### Description

Add timeouts to Redeem and Claim buttons in the liquality-swap to prevent initialization of multiple confirmation screens.

### Parts

- [ ] Add x
- [ ] Fix y
- [ ] Check z
